### PR TITLE
fix(redux-logger): import instead of require

### DIFF
--- a/src/app/redux/store.ts
+++ b/src/app/redux/store.ts
@@ -4,7 +4,7 @@ import { routerMiddleware } from 'react-router-redux';
 import thunk from 'redux-thunk';
 import rootReducer from './reducers';
 import { IStore } from './IStore';
-const createLogger = require('redux-logger');
+import createLogger from 'redux-logger';
 
 export function configureStore(history, initialState?: IStore): Redux.Store<IStore> {
 


### PR DESCRIPTION
for some reasons redux-logger does not have module.exports for createLogger() anymore. closes #33