### PR TITLE
style(linting): change to tslint:latest

### DIFF
--- a/src/app/helpers/TestHelper.tsx
+++ b/src/app/helpers/TestHelper.tsx
@@ -16,7 +16,7 @@ const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 
 /** Render Component */
-function renderComponent(ComponentClass: any, state?: Object, props?: Object): ReactWrapper<IStore, any> {
+function renderComponent(ComponentClass: any, state?: object, props?: object): ReactWrapper<IStore, any> {
   const store = createStore(rootReducer, state);
 
   return mount(

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "tslint:recommended",
+    "tslint:latest",
     "tslint-react"
   ],
   "rulesDirectory": [


### PR DESCRIPTION
has new linting and extends recommended. Includes ban usages of keywords like Function, Object, etc.
IE ban premitive types

Closes #43