### PR TITLE
feat(linting): remove linting on app start

### DIFF
--- a/config/webpack/dev.js
+++ b/config/webpack/dev.js
@@ -29,11 +29,7 @@ var config = {
   },
 
   module: {
-    rules: [{
-        enforce: 'pre',
-        test: /\.tsx?$/,
-        loader: 'tslint-loader'
-      },
+    rules: [
       {
         test: /\.tsx?$/,
         loader: 'react-hot-loader!awesome-typescript-loader'


### PR DESCRIPTION
When we're currently developing, there's no good reason to avoid starting the app because of linting
errors because we have proper git hooks and travis checks now

closes #41