### PR TITLE
chore(package): update enzyme to version 2.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "chai-enzyme": "^0.6.1",
     "cross-env": "^4.0.0",
     "electron": "^1.4.15",
-    "enzyme": "^2.7.0",
+    "enzyme": "^2.8.2",
     "fetch-mock": "^5.8.1",
     "file-loader": "^0.11.1",
     "husky": "^0.13.2",


### PR DESCRIPTION
Upgrading from 2.8.0 to 2.8.1 / 2.8.2 will break the build. Don't know the cause yet.

See https://github.com/airbnb/enzyme/issues/892.